### PR TITLE
pollos: update RAM specs to 32GB per node

### DIFF
--- a/pollos/README.md
+++ b/pollos/README.md
@@ -8,16 +8,16 @@ You can easily install them from microsite: https://www.pollos.cz
 
 ## HW
 
-- 4x HP Prodesk 600 G3 Mini i5-6500T
+- 4x HP ProDesk 600 G3 Mini i5-6500T (4 cores / 4 threads, 2.5–3.1 GHz)
 - 4x SSD Kingston 240GB
 - 32GB DDR4 SO-DIMM per node (2x 16GB), running at 2133 MHz:
 
-| Node | DIMM1 / DIMM3 | Part | Rank | ECC | Speed |
-|------|---------------|------|------|-----|-------|
-| gus | Kingston / Kingston | KF3200C20S4/16G | 1 | no | 2133 |
-| mike | Micron / Micron | 18ASF2G72HZ-2G3B1 | 2 | yes (inert) | 2133 |
-| walter | Micron / Micron | 18ASF2G72HZ-2G3B1 | 2 | yes (inert) | 2133 |
-| jesse | Micron / Micron | 18ASF2G72HZ-2G3B1 | 2 | yes (inert) | 2133 |
+| Node   | DIMM1 / DIMM3       | Part              | Rank | ECC         | Speed |
+|--------|---------------------|-------------------|------|-------------|-------|
+| gus    | Kingston / Kingston | KF3200C20S4/16G   | 1    | no          | 2133  |
+| mike   | Micron / Micron     | 18ASF2G72HZ-2G3B1 | 2    | yes (inert) | 2133  |
+| walter | Micron / Micron     | 18ASF2G72HZ-2G3B1 | 2    | yes (inert) | 2133  |
+| jesse  | Micron / Micron     | 18ASF2G72HZ-2G3B1 | 2    | yes (inert) | 2133  |
 
 ![stack photo](microsite/src/assets/img/stack-photo.jpg)
 

--- a/pollos/README.md
+++ b/pollos/README.md
@@ -9,7 +9,7 @@ You can easily install them from microsite: https://www.pollos.cz
 ## HW
 
 - 4x HP ProDesk 600 G3 Mini i5-6500T (4 cores / 4 threads, 2.5–3.1 GHz)
-- 4x SSD Kingston 240GB
+- 4x SATA SSD Kingston 240GB
 - 32GB DDR4 SO-DIMM per node (2x 16GB), running at 2133 MHz:
 
 | Node   | DIMM1 / DIMM3       | Part              | Rank | ECC         | Speed |

--- a/pollos/README.md
+++ b/pollos/README.md
@@ -10,8 +10,14 @@ You can easily install them from microsite: https://www.pollos.cz
 
 - 4x HP Prodesk 600 G3 Mini i5-6500T
 - 4x SSD Kingston 240GB
-- 2x 16GB Sk Hynix DDR4 3200Mhz HMA82GS6DJR8N - XN
-- 2x 16GB Kingston DDR4 3200MHz FURY so-dimm CL20 Impact
+- 32GB DDR4 SO-DIMM per node (2x 16GB), running at 2133 MHz:
+
+| Node | DIMM1 / DIMM3 | Part | Rank | ECC | Speed |
+|------|---------------|------|------|-----|-------|
+| gus | Kingston / Kingston | KF3200C20S4/16G | 1 | no | 2133 |
+| mike | Micron / Micron | 18ASF2G72HZ-2G3B1 | 2 | yes (inert) | 2133 |
+| walter | Micron / Micron | 18ASF2G72HZ-2G3B1 | 2 | yes (inert) | 2133 |
+| jesse | Micron / Micron | 18ASF2G72HZ-2G3B1 | 2 | yes (inert) | 2133 |
 
 ![stack photo](microsite/src/assets/img/stack-photo.jpg)
 

--- a/pollos/microsite/src/setup/index.html
+++ b/pollos/microsite/src/setup/index.html
@@ -14,7 +14,9 @@
   </p>
 
   <p class="intro">
-    <img src="/assets/img/stack-photo.jpg" alt="Stack of Mini PCs" />
+    <a href="https://github.com/landsman/homelab/tree/main/pollos#hw" target="_blank">
+      <img src="/assets/img/stack-photo.jpg" alt="Stack of Mini PCs" />
+    </a>
   </p>
 
   <p class="intro">


### PR DESCRIPTION
Update `pollos/README.md` HW section after the RAM 16→32 GB upgrade.

Each node now runs **2x 16GB DDR4 SO-DIMM (32GB)** at 2133 MHz:

| Node | Part | Rank | ECC |
|------|------|------|-----|
| gus | Kingston KF3200C20S4/16G | 1 | no |
| mike / walter / jesse | Micron 18ASF2G72HZ-2G3B1 | 2 | yes (inert) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)