### PR TITLE
feat(dashboard): add Better Stack to status page and home

### DIFF
--- a/dashboard/public/icons/services/betterstack.svg
+++ b/dashboard/public/icons/services/betterstack.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+  <defs>
+    <linearGradient id="bs" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2a3145"/>
+      <stop offset="1" stop-color="#11151f"/>
+    </linearGradient>
+  </defs>
+  <rect width="20" height="20" rx="4.5" fill="url(#bs)"/>
+  <g fill="#fff">
+    <path d="M6.6 8 Q6.9 11 6.5 13.4 Q5.8 14.2 5 13.4 Q5.5 11 6.6 8 Z"/>
+    <path d="M10 5.5 Q10.5 9.5 10.1 13.5 Q9 14.5 7.9 13.5 Q8.5 9.5 10 5.5 Z"/>
+    <path d="M14 3.5 Q14.5 9 14 13.2 Q12.7 14.4 11.4 13.2 Q12 8 14 3.5 Z"/>
+  </g>
+</svg>

--- a/dashboard/src/features/common/hotkey/hotkey.ts
+++ b/dashboard/src/features/common/hotkey/hotkey.ts
@@ -11,6 +11,7 @@ export enum Hotkey {
   SHIFT_FIVE = 'Shift+5',
   SHIFT_SIX = 'Shift+6',
   SHIFT_SEVEN = 'Shift+7',
+  SHIFT_EIGHT = 'Shift+8',
   SHIFT_A = 'Shift+A',
   SHIFT_B = 'Shift+B',
   SHIFT_C = 'Shift+C',

--- a/dashboard/src/features/home/data/service.icon.ts
+++ b/dashboard/src/features/home/data/service.icon.ts
@@ -3,6 +3,7 @@ export enum ServiceIcon {
   APPLE_NOTES = 'apple-notes',
   BLUESKY = 'bluesky',
   AZURE_DEVOPS = 'azure-devops',
+  BETTERSTACK = 'betterstack',
   CLOUDFLARE = 'cloudflare',
   TAILSCALE = 'tailscale',
   X = 'x',

--- a/dashboard/src/features/home/data/services.ts
+++ b/dashboard/src/features/home/data/services.ts
@@ -124,6 +124,7 @@ export const HOME_CATEGORIES: HomeCategory[] = [
         name: 'Better Stack',
         url: 'https://uptime.betterstack.com',
         icon: ServiceIcon.BETTERSTACK,
+        shortcut: Hotkey.SHIFT_EIGHT,
       },
       {
         name: 'Supabase',

--- a/dashboard/src/features/home/data/services.ts
+++ b/dashboard/src/features/home/data/services.ts
@@ -121,6 +121,11 @@ export const HOME_CATEGORIES: HomeCategory[] = [
       { name: 'Vaadin Docs', url: 'https://vaadin.com/docs', icon: ServiceIcon.VAADIN },
       { name: 'Azure DevOps', url: 'https://dev.azure.com', icon: ServiceIcon.AZURE_DEVOPS },
       {
+        name: 'Better Stack',
+        url: 'https://uptime.betterstack.com',
+        icon: ServiceIcon.BETTERSTACK,
+      },
+      {
         name: 'Supabase',
         url: 'https://supabase.com/dashboard/projects',
         icon: ServiceIcon.SUPABASE,

--- a/dashboard/src/features/status-page/api/betterstack.ts
+++ b/dashboard/src/features/status-page/api/betterstack.ts
@@ -49,7 +49,7 @@ function resourceStatus(status: string): string {
 }
 
 export async function fetchBetterStack(baseUrl: string): Promise<StatusPageData> {
-  const res = await fetch(`${baseUrl}/index.json`, { cache: 'no-store' })
+  const res = await fetch(`${baseUrl.replace(/\/$/, '')}/index.json`, { cache: 'no-store' })
   if (!res.ok) throw new Error(`HTTP ${res.status}`)
   const data = (await res.json()) as BetterStackResponse
 

--- a/dashboard/src/features/status-page/api/betterstack.ts
+++ b/dashboard/src/features/status-page/api/betterstack.ts
@@ -1,0 +1,99 @@
+import { match } from 'ts-pattern'
+import type { StatusPageData, StatusComponent, Incident, IncidentUpdate } from './types'
+
+// Better Stack status pages expose a JSON:API document at `${baseUrl}/index.json`.
+// https://betterstack.com/docs/uptime/status-pages/subscribing-to-status-updates/subscribing-to-api/
+
+interface BetterStackResource {
+  id: string
+  type: 'status_page_resource'
+  attributes: { public_name: string; status: string }
+}
+
+interface BetterStackUpdate {
+  id: string
+  type: 'status_update'
+  attributes: { message: string; published_at: string | null }
+}
+
+interface BetterStackReport {
+  id: string
+  type: 'status_report'
+  attributes: { title: string; report_type: string; aggregate_state: string }
+  relationships?: { status_updates?: { data: Array<{ id: string }> } }
+}
+
+type BetterStackIncluded = BetterStackResource | BetterStackUpdate | BetterStackReport
+
+interface BetterStackResponse {
+  data: { attributes: { aggregate_state: string } }
+  included?: BetterStackIncluded[]
+}
+
+function aggregateToIndicator(state: string): string {
+  return match(state)
+    .with('operational', () => 'none')
+    .with('degraded', () => 'minor')
+    .with('downtime', () => 'major')
+    .with('maintenance', () => 'maintenance')
+    .otherwise(() => 'minor')
+}
+
+function resourceStatus(status: string): string {
+  return match(status)
+    .with('operational', () => 'operational')
+    .with('degraded', () => 'degraded_performance')
+    .with('downtime', () => 'major_outage')
+    .with('maintenance', () => 'under_maintenance')
+    .otherwise(() => 'operational')
+}
+
+export async function fetchBetterStack(baseUrl: string): Promise<StatusPageData> {
+  const res = await fetch(`${baseUrl}/index.json`, { cache: 'no-store' })
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const data = (await res.json()) as BetterStackResponse
+
+  const included = data.included ?? []
+  const indicator = aggregateToIndicator(data.data.attributes.aggregate_state)
+
+  const components: StatusComponent[] = included
+    .filter((x): x is BetterStackResource => x.type === 'status_page_resource')
+    .filter(r => r.attributes.status !== 'not_monitored')
+    .map(r => ({
+      id: r.id,
+      name: r.attributes.public_name,
+      status: resourceStatus(r.attributes.status),
+      group: false,
+      group_id: null,
+    }))
+
+  const updatesById = new Map<string, BetterStackUpdate>(
+    included.filter((x): x is BetterStackUpdate => x.type === 'status_update').map(u => [u.id, u])
+  )
+
+  const incidents: Incident[] = included
+    .filter((x): x is BetterStackReport => x.type === 'status_report')
+    .filter(r => r.attributes.aggregate_state !== 'resolved')
+    .map(r => {
+      const updates: IncidentUpdate[] = (r.relationships?.status_updates?.data ?? [])
+        .map(ref => updatesById.get(ref.id))
+        .filter((u): u is BetterStackUpdate => Boolean(u))
+        .map(u => ({ body: u.attributes.message, created_at: u.attributes.published_at ?? '' }))
+      return {
+        id: r.id,
+        name: r.attributes.title,
+        status:
+          r.attributes.report_type === 'maintenance' ? 'maintenance' : r.attributes.aggregate_state,
+        incident_updates: updates,
+      }
+    })
+
+  return {
+    status: {
+      indicator,
+      description: indicator === 'none' ? 'ok' : data.data.attributes.aggregate_state,
+    },
+    components,
+    incidents,
+  }
+}

--- a/dashboard/src/features/status-page/hooks/use-status-page.ts
+++ b/dashboard/src/features/status-page/hooks/use-status-page.ts
@@ -5,6 +5,7 @@ import type { StatusPageData, StatusComponent, Incident } from '../api/types'
 import { fetchAtlassian } from '../api/atlassian'
 import { fetchStatusio } from '../api/statusio'
 import { fetchInstatus } from '../api/instatus'
+import { fetchBetterStack } from '../api/betterstack'
 import { fetchGoogleWorkspace } from '../api/google-workspace'
 import { fetchIncidentio } from '../api/incidentio'
 import { fetchSlack } from '../api/slack'
@@ -27,6 +28,7 @@ async function fetchStatusPage(service: Service): Promise<StatusPageData> {
     return await match(service)
       .with({ type: SERVICE_TYPE.STATUSIO }, s => fetchStatusio(s.statusioId!))
       .with({ type: SERVICE_TYPE.INSTATUS }, s => fetchInstatus(s.url))
+      .with({ type: SERVICE_TYPE.BETTERSTACK }, s => fetchBetterStack(s.url))
       .with({ type: SERVICE_TYPE.GOOGLE_WORKSPACE }, () => fetchGoogleWorkspace())
       .with({ type: SERVICE_TYPE.INCIDENTIO }, s => fetchIncidentio(s.url))
       .with({ type: SERVICE_TYPE.SLACK }, () => fetchSlack())

--- a/dashboard/src/features/status-page/services.ts
+++ b/dashboard/src/features/status-page/services.ts
@@ -2,6 +2,7 @@ export const SERVICE_TYPE = {
   ATLASSIAN: 'atlassian',
   STATUSIO: 'statusio',
   INSTATUS: 'instatus',
+  BETTERSTACK: 'betterstack',
   GOOGLE_WORKSPACE: 'google-workspace',
   INCIDENTIO: 'incidentio',
   SLACK: 'slack',
@@ -86,6 +87,13 @@ export const SERVICES: Service[] = [
     url: 'https://status.maven.org',
     type: SERVICE_TYPE.ATLASSIAN,
     keywords: ['java'],
+  },
+  {
+    name: 'Better Stack',
+    url: 'https://status.betterstack.com',
+    type: SERVICE_TYPE.BETTERSTACK,
+    icon: 'betterstack',
+    keywords: ['monitoring', 'uptime', 'status', 'logs', 'telemetry', 'observability'],
   },
   {
     name: 'Perplexity',


### PR DESCRIPTION
## What

Adds **Better Stack** to the dashboard.

### `/status`
- New `betterstack` platform — consumes the JSON:API document at `{url}/index.json` (`aggregate_state` → indicator, resources → components, non-resolved status reports → incidents).
- `not_monitored` resources are filtered out (Better Stack shows them as informational-only, not actively monitored).
- Better Stack card added to the external section.

### `/` (home)
- Better Stack link added to the **Development** section.

### Icon
- Brand SVG at `public/icons/services/betterstack.svg`, reused by both pages.

## Notes
- API verified live: `status.betterstack.com/index.json` returns `200` with `access-control-allow-origin: *`, so no proxy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)