### PR TITLE
fix(pollos/infra): apply daily maintenance window to app monitors

### DIFF
--- a/pollos/infra/monitoring.tf
+++ b/pollos/infra/monitoring.tf
@@ -18,8 +18,11 @@ locals {
   # taking every monitored target (nodes AND apps) offline. Shared so the node
   # and service monitors can't drift; applied to both (see status_page.tf).
   daily_maintenance = {
-    maintenance_from     = "04:55:00"
-    maintenance_to       = "05:20:00"
+    maintenance_from = "04:55:00"
+    maintenance_to   = "05:20:00"
+    # BetterStack wants a Rails ActiveSupport::TimeZone friendly name (e.g.
+    # "Prague", "Amsterdam") — NOT an IANA id like "Europe/Prague"; days are the
+    # abbreviated forms. See https://betterstack.com/docs/uptime/api/create-a-new-monitor/
     maintenance_timezone = "Prague"
     maintenance_days     = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
   }

--- a/pollos/infra/monitoring.tf
+++ b/pollos/infra/monitoring.tf
@@ -13,6 +13,16 @@ locals {
   # single label under the zone (gus-health.pollos.cz) so Universal SSL's
   # *.pollos.cz cert covers it — a nested *.health.pollos.cz would not.
   zone_domain = "pollos.cz"
+
+  # Daily maintenance window — the homelab network/router reboots in this hour,
+  # taking every monitored target (nodes AND apps) offline. Shared so the node
+  # and service monitors can't drift; applied to both (see status_page.tf).
+  daily_maintenance = {
+    maintenance_from     = "04:55:00"
+    maintenance_to       = "05:20:00"
+    maintenance_timezone = "Prague"
+    maintenance_days     = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+  }
 }
 
 # One tunnel per box → each node is up/down independently. config_src
@@ -82,10 +92,10 @@ resource "betteruptime_monitor" "health" {
   regions            = ["eu"]
 
   # Daily maintenance window — router reboot/update in this hour
-  maintenance_from     = "04:55:00"
-  maintenance_to       = "05:20:00"
-  maintenance_timezone = "Prague"
-  maintenance_days     = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+  maintenance_from     = local.daily_maintenance.maintenance_from
+  maintenance_to       = local.daily_maintenance.maintenance_to
+  maintenance_timezone = local.daily_maintenance.maintenance_timezone
+  maintenance_days     = local.daily_maintenance.maintenance_days
 }
 
 output "health_tunnel_tokens" {

--- a/pollos/infra/status_page.tf
+++ b/pollos/infra/status_page.tf
@@ -73,6 +73,13 @@ resource "betteruptime_monitor" "service" {
   monitor_group_id   = tonumber(betteruptime_monitor_group.apps.id)
   check_frequency    = each.value.check_frequency # seconds (per service)
   regions            = ["eu"]
+
+  # Same daily window as the node monitors — the apps live on the same homelab
+  # network and go down during the morning reboot (see monitoring.tf).
+  maintenance_from     = local.daily_maintenance.maintenance_from
+  maintenance_to       = local.daily_maintenance.maintenance_to
+  maintenance_timezone = local.daily_maintenance.maintenance_timezone
+  maintenance_days     = local.daily_maintenance.maintenance_days
 }
 
 resource "betteruptime_status_page_resource" "service" {


### PR DESCRIPTION
## Why

5am Prague incident emails from BetterStack despite the daily maintenance window being "set up". The window (`04:55–05:20` Prague) was only applied to the **node health monitors** (`monitoring.tf`), not the **app monitors** (`status_page.tf`: welcome/eat/git/read/music).

The morning homelab/router reboot takes the insuit.cz apps offline too, so the unmuted `service` monitors fired incidents — emails at ~5:00 and 5:04 (consistent with the 300s-`check_frequency` apps `eat`/`git`/`read` catching the outage on adjacent polls). The node monitors stayed correctly silent.

## What

- Factor the maintenance window into a shared `daily_maintenance` local in `monitoring.tf`.
- Reference it from `betteruptime_monitor.health` (no behavior change).
- Apply it to `betteruptime_monitor.service` in `status_page.tf` — the actual fix.

Shared local so the two monitor sets can't drift.

## Verify
- `terraform fmt` clean. (`validate` not run here — local TF is 1.14.5 < required 1.15 and providers aren't initialized; environmental only.)
- After `apply`, confirm `maintenance_from/to/timezone/days` is set on the app monitors in BetterStack.

## Caveat
Window ends `05:20` Prague — if apps finish booting later, widen `maintenance_to`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)